### PR TITLE
Remove deprecated JSHint options

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -16,8 +16,6 @@
     "undef": true,
     "unused": true,
     "strict": true,
-    "trailing": true,
-    "smarttabs": true,
     "globals" : {
         "chrome": true
     }


### PR DESCRIPTION
`trailing` and `smarttabs` JSHint options are deprecated [since v2.5.0.](https://github.com/jshint/jshint/releases/tag/2.5.0)
